### PR TITLE
fix(startup.sh) 修复无法检查到 docker 没有设置端口直接使用 unix socket 情况

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -14,7 +14,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 	serverComposeFile="docker-compose-bloc-server-mac.yml"
 elif [[ "$OSTYPE" == "linux"* ]]; then
 	# Linux
-	app_name="docker"
+	app_name="dockerd"
 	serverComposeFile="docker-compose-bloc-server-linux.yml"
 else
 	# tmp to just use linux. later should support windows
@@ -31,7 +31,7 @@ check_env() {
 	cd $(dirname $0); pwd
 
 	# check docker status
-	lsof -nP | grep LISTEN |grep $app_name
+	lsof -UnP |grep $app_name
 	if [ $? -eq 0 ]; then
 		echo "docker is ready"
 	else


### PR DESCRIPTION
本来打算用 `docker stats --no-stream` 看出输出是否为 1 来检查 docker 是否正确启动，结果 centos 测试执行 docker 命令会自动启动，很奇怪，所以用了当前这种讨巧的方式